### PR TITLE
Fix: Remove newline characters from API URLs to address security issue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,6 @@ This file provides guidance to agents when working with code in this repository.
 - Network debugging menggunakan Chucker (hanya di debugImplementation) untuk inspeksi traffic API
 - Glide image loading dengan CircleCrop transform untuk menampilkan avatar pengguna berbentuk bulat
 - UserAdapter dan PemanfaatanAdapter menggunakan notifyDataSetChanged() sebagai pengganti DiffUtil untuk kemudahan implementasi
-- API base URL mengandung karakter newline yang harus dipertahankan: "https://api.apispreadsheets.com/data/QjX6hB1ST2IDKaxB/\n\n"
 
 ## Code Style
 - Kotlin menggunakan "official" code style (kotlin.code.style=official)

--- a/app/src/main/java/com/example/iurankomplek/network/ApiConfig.kt
+++ b/app/src/main/java/com/example/iurankomplek/network/ApiConfig.kt
@@ -7,9 +7,9 @@ object ApiConfig {
     // Use mock API in debug mode or when running in Docker
     private const val USE_MOCK_API = BuildConfig.DEBUG || System.getenv("DOCKER_ENV") != null
     private const val BASE_URL = if (USE_MOCK_API) {
-        "http://api-mock:5000/data/QjX6hB1ST2IDKaxB/\n\n"
+        "http://api-mock:5000/data/QjX6hB1ST2IDKaxB/"
     } else {
-        "https://api.apispreadsheets.com/data/QjX6hB1ST2IDKaxB/\n\n"
+        "https://api.apispreadsheets.com/data/QjX6hB1ST2IDKaxB/"
     }
     
     fun getApiService(): ApiService {


### PR DESCRIPTION
# Summary
This PR fixes security issue #61 by removing problematic newline characters from the API base URLs that were causing connection failures and potential security vulnerabilities.

## Implementation details
- Removed newline characters () from both API URL constants in 
- Updated  to remove the guidance that instructed maintaining newline characters
- The fix addresses potential HTTP request issues and malformed URLs

## Testing
- Verified syntax of the changes
- Both mock API and production API URLs now have proper formatting

## Breaking changes
No breaking changes - this is a security fix that maintains the same API functionality while correcting URL formatting.