### PR TITLE
feat: implement DiffUtil for UserAdapter and PemanfaatanAdapter

### DIFF
--- a/app/src/main/java/com/example/iurankomplek/PemanfaatanAdapter.kt
+++ b/app/src/main/java/com/example/iurankomplek/PemanfaatanAdapter.kt
@@ -3,30 +3,60 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 
 import com.example.iurankomplek.model.DataItem
-class PemanfaatanAdapter(private val pemanfaatan:MutableList<DataItem>) :
+
+class PemanfaatanAdapter(private var pemanfaatan: MutableList<DataItem>) :
     RecyclerView.Adapter<PemanfaatanAdapter.ListViewHolder>() {
+    
     constructor() : this(mutableListOf())
+    
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ListViewHolder {
         val view: View =
             LayoutInflater.from(parent.context).inflate(R.layout.item_pemanfaatan, parent, false)
         return ListViewHolder(view)
     }
+    
     fun setPemanfaatan(dataItems: List<DataItem>) {
-        pemanfaatan.clear()
-        pemanfaatan.addAll(dataItems)
-        notifyDataSetChanged()
+        val diffCallback = PemanfaatanDiffCallback(this.pemanfaatan, dataItems)
+        val diffResult = DiffUtil.calculateDiff(diffCallback)
+        
+        this.pemanfaatan.clear()
+        this.pemanfaatan.addAll(dataItems)
+        diffResult.dispatchUpdatesTo(this)
     }
+    
     override fun getItemCount(): Int = pemanfaatan.size
+    
     override fun onBindViewHolder(holder: ListViewHolder, position: Int) {
         val item = pemanfaatan[position]
         holder.tvPemanfaatan.text = "-" + item.pemanfaatan_iuran + ":"
         holder.tvTotalIuranRekap.text = item.pengeluaran_iuran_warga.toString()
     }
+    
     class ListViewHolder(itemView: View): RecyclerView.ViewHolder(itemView){
         var tvPemanfaatan: TextView = itemView.findViewById(R.id.itemPemanfaatan)
         var tvTotalIuranRekap: TextView = itemView.findViewById(R.id.itemDanaPemanfaatan)
+    }
+    
+    class PemanfaatanDiffCallback(
+        private val oldList: List<DataItem>,
+        private val newList: List<DataItem>
+    ) : DiffUtil.Callback() {
+        
+        override fun getOldListSize(): Int = oldList.size
+        
+        override fun getNewListSize(): Int = newList.size
+        
+        override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            // For pemanfaatan items, use pemanfaatan_iuran as it's likely to be unique for each expense
+            return oldList[oldItemPosition].pemanfaatan_iuran == newList[newItemPosition].pemanfaatan_iuran
+        }
+        
+        override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            return oldList[oldItemPosition] == newList[newItemPosition]
+        }
     }
 }

--- a/app/src/main/java/com/example/iurankomplek/UserAdapter.kt
+++ b/app/src/main/java/com/example/iurankomplek/UserAdapter.kt
@@ -4,13 +4,16 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.resource.bitmap.CircleCrop
 import com.bumptech.glide.request.RequestOptions
 import com.example.iurankomplek.model.DataItem
-class UserAdapter(private val users: MutableList<DataItem>):
+
+class UserAdapter(private var users: MutableList<DataItem>):
     RecyclerView.Adapter<UserAdapter.ListViewHolder>(){
+    
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ListViewHolder {
         val view: View =
             LayoutInflater.from(parent.context).inflate(R.layout.item_list, parent,false)
@@ -18,22 +21,31 @@ class UserAdapter(private val users: MutableList<DataItem>):
             view
         )
     }
-    fun setUsers(users: List<DataItem>) {
+    
+    fun setUsers(newUsers: List<DataItem>) {
+        val diffCallback = UserDiffCallback(this.users, newUsers)
+        val diffResult = DiffUtil.calculateDiff(diffCallback)
+        
         this.users.clear()
-        this.users.addAll(users)
-        notifyDataSetChanged()
+        this.users.addAll(newUsers)
+        diffResult.dispatchUpdatesTo(this)
     }
+    
     fun addUser(newUser: DataItem?) {
         newUser?.let {
             users.add(it)
             notifyItemInserted(users.lastIndex)
         }
     }
+    
     fun clear(){
+        val size = users.size
         users.clear()
-        notifyDataSetChanged()
+        notifyItemRangeRemoved(0, size)
     }
+    
     override fun getItemCount(): Int = users.size
+    
     override fun onBindViewHolder(holder: ListViewHolder, position: Int){
         val user = users[position]
         Glide.with(holder.itemView.context)
@@ -56,5 +68,25 @@ class UserAdapter(private val users: MutableList<DataItem>):
         var tvAddress: TextView = itemView.findViewById(R.id.itemAddress)
         var tvIuranPerwarga: TextView = itemView.findViewById(R.id.itemIuranPerwarga)
         var tvTotalIuranIndividu: TextView = itemView.findViewById(R.id.itemIuranIndividu)
+    }
+    
+    class UserDiffCallback(
+        private val oldList: List<DataItem>,
+        private val newList: List<DataItem>
+    ) : DiffUtil.Callback() {
+        
+        override fun getOldListSize(): Int = oldList.size
+        
+        override fun getNewListSize(): Int = newList.size
+        
+        override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            // Since there's no explicit ID, use a combination of fields that would uniquely identify a user
+            // Using email as it's typically unique, or a combination of name and address
+            return oldList[oldItemPosition].email == newList[newItemPosition].email
+        }
+        
+        override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            return oldList[oldItemPosition] == newList[newItemPosition]
+        }
     }
 }


### PR DESCRIPTION
## Summary
This PR addresses issue #25 by implementing DiffUtil for both UserAdapter and PemanfaatanAdapter to replace inefficient notifyDataSetChanged() calls. This significantly improves RecyclerView performance and enables smooth item change animations.

## Implementation details
- Added DiffUtil.Callback implementation to both adapters
- Used email field for item identification in UserAdapter (typically unique)
- Used pemanfaatan_iuran field for item identification in PemanfaatanAdapter 
- Updated setUsers() and setPemanfaatan() methods to use DiffUtil instead of notifyDataSetChanged()
- Maintained existing functionality while improving performance

## Testing
- Verified that both adapters still function correctly
- Ensured proper item identification and content comparison logic
- Confirmed smooth animations work for item changes

## Breaking changes
None - this is a performance optimization that maintains the same public API

Fixes #25