### PR TITLE
Fix: Add proper image caching strategy to improve performance

### DIFF
--- a/app/src/main/java/com/example/iurankomplek/UserAdapter.kt
+++ b/app/src/main/java/com/example/iurankomplek/UserAdapter.kt
@@ -10,6 +10,7 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.load.resource.bitmap.CircleCrop
 import com.bumptech.glide.request.RequestOptions
 import com.example.iurankomplek.model.DataItem
+import com.example.iurankomplek.utils.ImageLoader
 
 class UserAdapter(private var users: MutableList<DataItem>):
     RecyclerView.Adapter<UserAdapter.ListViewHolder>(){
@@ -49,16 +50,15 @@ class UserAdapter(private var users: MutableList<DataItem>):
     
     override fun getItemCount(): Int = users.size
     
-     override fun onBindViewHolder(holder: ListViewHolder, position: Int){
-         val user = users[position]
-         
-         // Load avatar image with error handling
-         val avatarUrl = user.avatar.takeIf { it.isNotBlank() }
-         Glide.with(holder.itemView.context)
-             .load(avatarUrl)
-             .apply(RequestOptions().override(80, 80).placeholder(R.drawable.icon_avatar).error(R.drawable.icon_avatar))
-             .transform(CircleCrop())
-             .into(holder.tvAvatar)
+override fun onBindViewHolder(holder: ListViewHolder, position: Int){
+          val user = users[position]
+          
+          // Load avatar image with proper caching and error handling
+          ImageLoader.loadCircularImage(
+              context = holder.itemView.context,
+              imageView = holder.tvAvatar,
+              url = user.avatar
+          )
          
          // Safely construct and display user name
          val userName = mutableListOf<String>().apply {

--- a/app/src/main/java/com/example/iurankomplek/utils/ImageLoader.kt
+++ b/app/src/main/java/com/example/iurankomplek/utils/ImageLoader.kt
@@ -1,0 +1,47 @@
+package com.example.iurankomplek.utils
+
+import android.content.Context
+import android.widget.ImageView
+import com.bumptech.glide.Glide
+import com.bumptech.glide.load.engine.DiskCacheStrategy
+import com.bumptech.glide.load.resource.bitmap.CircleCrop
+import com.bumptech.glide.request.RequestOptions
+import java.net.URL
+
+object ImageLoader {
+    fun loadCircularImage(
+        context: Context,
+        imageView: ImageView,
+        url: String?,
+        placeholderResId: Int = R.drawable.icon_avatar,
+        errorResId: Int = R.drawable.icon_avatar,
+        size: Int = 80
+    ) {
+        val validUrl = url.takeIf { 
+            it != null && it.isNotBlank() && isValidUrl(it) 
+        }
+        
+        Glide.with(context)
+            .load(validUrl)
+            .apply(
+                RequestOptions()
+                    .override(size, size)
+                    .placeholder(placeholderResId)
+                    .error(errorResId)
+                    .diskCacheStrategy(DiskCacheStrategy.ALL)
+                    .skipMemoryCache(false)
+                    .centerCrop()
+            )
+            .transform(CircleCrop())
+            .into(imageView)
+    }
+    
+    private fun isValidUrl(url: String): Boolean {
+        return try {
+            URL(url).toURI()
+            true
+        } catch (e: Exception) {
+            false
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This PR addresses issue #115 by implementing a proper image caching strategy for avatar loading in the UserAdapter. Key changes include:

- Created an ImageLoader utility class with proper caching configuration
- Implemented disk and memory caching using Glide's DiskCacheStrategy.ALL
- Added error handling and fallback for failed image loads
- Added URL validation to prevent loading invalid image URLs
- Updated UserAdapter to use the new ImageLoader utility

## Implementation Details
- Added ImageLoader.kt utility class in the utils package
- The utility handles proper Glide configuration with caching strategies
- Includes validation for URL format before attempting to load images
- Uses CircleCrop transformation for consistent avatar display

## Testing
- Manual verification of the code changes
- The implementation follows best practices for Glide image loading in Android

## Breaking Changes
- No breaking changes, this is a performance enhancement

## Additional Notes
- The solution addresses the inefficient image loading without caching strategy mentioned in the issue
- Performance should improve significantly with proper caching, especially for users opening the app repeatedly