### PR TITLE
Fix #92: Remove unused grey color resource

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,8 +7,7 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
-    <color name="grey">#808080</color> <!-- Warna abu-abu -->
-<color name="cream">#F5F5DC</color>
-<color name="green">#00FF00</color>
-<color name="peach">#FFDAB9</color>
+ <color name="cream">#F5F5DC</color>
+ <color name="green">#00FF00</color>
+ <color name="peach">#FFDAB9</color>
 </resources>


### PR DESCRIPTION
## Summary
This PR addresses issue #92 by removing the unused grey color resource from colors.xml. The original issue mentioned unused item_laporan.xml and LaporanAdapter.kt files, but these have already been removed from the codebase. The only unused resource I found was the grey color definition in colors.xml.

## Implementation details
- Removed the unused grey color definition from app/src/main/res/values/colors.xml
- The grey color was defined but never referenced anywhere in the codebase

## Testing
- Verified that all remaining color resources are properly used in the application
- No functional changes to the app behavior

## Breaking changes
- None - only removes an unused resource