### PR TITLE
Fix duplicate swipe refresh setup in MainActivity

### DIFF
--- a/app/src/main/java/com/example/iurankomplek/MainActivity.kt
+++ b/app/src/main/java/com/example/iurankomplek/MainActivity.kt
@@ -33,7 +33,6 @@ class MainActivity : BaseActivity() {
         binding.rvUsers.adapter = adapter
         
         setupSwipeRefresh()
-         setupSwipeRefresh()
          observeUserState()
          viewModel.loadUsers()
      }


### PR DESCRIPTION
## Summary
This PR fixes issue #209 by removing the duplicate call to setupSwipeRefresh() in MainActivity.kt.

## Implementation details
- Removed the duplicate setupSwipeRefresh() call on line 36 of MainActivity.kt
- The swipe refresh functionality remains intact with the single remaining call
- This prevents redundant listener registration that could cause performance issues and potential memory leaks

## Testing
- No specific tests were added as this is a simple removal of duplicate code
- The existing functionality remains unchanged

## Breaking changes
- No breaking changes - this is a pure bug fix

Fixes #209